### PR TITLE
Feature: Token address as beneficiary

### DIFF
--- a/init/createVesting.js
+++ b/init/createVesting.js
@@ -35,8 +35,8 @@ const createVesting = async () => {
   let vestingSigner = null;
 
   const createVestingFromSchedule = async (provider, schedule) => {
-    const startTs = new anchor.BN(schedule.startTs / 1000 + 2000);
-    const endTs = new anchor.BN(schedule.endTs + 600);
+    const startTs = new anchor.BN(schedule.startTs);
+    const endTs = new anchor.BN(schedule.endTs);
     const periodCount = new anchor.BN(schedule.periodCount);
     const beneficiary = schedule.beneficiary;
     const depositAmount = new anchor.BN(schedule.depositAmount);
@@ -60,8 +60,8 @@ const createVesting = async () => {
     console.log({
       vesting: vesting.publicKey.toBase58(),
       vault: vault.publicKey.toBase58(),
-      depositor: depositor.publicKey.toBase58(),
-      depositorAuthority: provider.wallet.publicKey.toBase58(),
+      depositor: tokenAddress.toBase58(),
+      depositorAuthority: depositor.publicKey.toBase58(),
       mint: mint.toBase58()
     })
 
@@ -79,12 +79,12 @@ const createVesting = async () => {
             vesting: vesting.publicKey,
             vault: vault.publicKey,
             depositor: tokenAddress,
-            depositorAuthority: provider.wallet.publicKey,
+            depositorAuthority: depositor.publicKey,
             tokenProgram: TokenInstructions.TOKEN_PROGRAM_ID,
             rent: anchor.web3.SYSVAR_RENT_PUBKEY,
             clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
           },
-          signers: [vesting, vault],
+          signers: [vesting, vault, depositor],
           instructions: [
             await vestingProgram.account.vesting.createInstruction(vesting),
             ...(await serumCmn.createTokenAccountInstrs(

--- a/init/withdrawVesting.js
+++ b/init/withdrawVesting.js
@@ -39,7 +39,6 @@ const withdrawVested = async () => {
     vestingProgram.programId
   );
   vestingSigner = _vestingSigner;  
-  
   console.log("Getting maximum withdrawal amount");
   const availableWithdrawalTxSignature = await vestingProgram.rpc.availableForWithdrawal({
     accounts: {
@@ -54,19 +53,7 @@ const withdrawVested = async () => {
     let msg = parsedTx.meta.logMessages[1];
     const availableFunds = JSON.parse(msg.substr(msg.indexOf("{"))).result;
     console.log("Available for withdraw " + availableFunds);
-    let token = null;
-    if (process.env.WITHDRAWAL_TOKEN_ACCOUNT) {
-        token = process.env.WITHDRAWAL_TOKEN_ACCOUNT;
-    } else {
-        console.log("WITHDRAWAL_TOKEN_ACCOUNT wasn't found; creating new token account")
-        token = await serumCmn.createTokenAccount(
-            provider,
-            mint,
-            provider.wallet.publicKey
-        );
-        console.log("Created new token account " + token.toBase58() +  "with owner " + provider.wallet.publicKey.toBase58());
-    }
-    const withdrawTokenAddress = token;
+    const withdrawTokenAddress = vestingAccount.beneficiary;
     
     console.log("Witdrawing available funds to the account " + withdrawTokenAddress.toBase58());
     await vestingProgram.rpc.withdraw(
@@ -74,10 +61,9 @@ const withdrawVested = async () => {
         {
           accounts: {
             vesting: vesting,
-            beneficiary: provider.wallet.publicKey,
+            beneficiary: withdrawTokenAddress,
             vault: vestingAccount.vault,
             vestingSigner,
-            token: withdrawTokenAddress,
             tokenProgram: TokenInstructions.TOKEN_PROGRAM_ID,
             clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
           },

--- a/programs/vesting/src/lib.rs
+++ b/programs/vesting/src/lib.rs
@@ -253,15 +253,13 @@ pub struct Withdraw<'info> {
     // Vesting.
     #[account(mut, has_one = beneficiary, has_one = vault)]
     vesting: ProgramAccount<'info, Vesting>,
-    #[account(signer)]
-    beneficiary: AccountInfo<'info>,
     #[account(mut)]
     vault: CpiAccount<'info, TokenAccount>,
     #[account(seeds = [vesting.to_account_info().key.as_ref(), &[vesting.nonce]])]
     vesting_signer: AccountInfo<'info>,
     // Withdraw receiving target..
     #[account(mut)]
-    token: CpiAccount<'info, TokenAccount>,
+    beneficiary: CpiAccount<'info, TokenAccount>,
     // Misc.
     #[account("token_program.key == &token::ID")]
     token_program: AccountInfo<'info>,
@@ -426,7 +424,7 @@ impl<'a, 'b, 'c, 'info> From<&Withdraw<'info>> for CpiContext<'a, 'b, 'c, 'info,
     fn from(accounts: &Withdraw<'info>) -> CpiContext<'a, 'b, 'c, 'info, Transfer<'info>> {
         let cpi_accounts = Transfer {
             from: accounts.vault.to_account_info(),
-            to: accounts.token.to_account_info(),
+            to: accounts.beneficiary.to_account_info(),
             authority: accounts.vesting_signer.to_account_info(),
         };
         let cpi_program = accounts.token_program.to_account_info();

--- a/programs/vesting/src/lib.rs
+++ b/programs/vesting/src/lib.rs
@@ -147,6 +147,9 @@ pub mod lockup {
         let after_amount = ctx.accounts.transfer.vault.reload()?.amount;
 
         // CPI safety checks.
+        if before_amount <= after_amount {
+            return Err(ErrorCode::WhitelistWithdrawWrongCPI.into());
+        }
         let withdraw_amount = before_amount - after_amount;
         if withdraw_amount > amount {
             return Err(ErrorCode::WhitelistWithdrawLimit.into());
@@ -387,6 +390,8 @@ pub enum ErrorCode {
     InsufficientWhitelistDepositAmount,
     #[msg("Cannot deposit more than withdrawn")]
     WhitelistDepositOverflow,
+    #[msg("CPI is trying to deposit while it should withdraw")]
+    WhitelistWithdrawWrongCPI,
     #[msg("Tried to withdraw over the specified limit")]
     WhitelistWithdrawLimit,
     #[msg("Whitelist entry not found.")]


### PR DESCRIPTION
Changed vesting so that it will point to a token address, not beneficiary wallet pubkey. It will allow locking funds to a multi-signature token owner as it cannot be used as a signer.